### PR TITLE
chore: update express and axios dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ npm install
 npm run build
 ```
 
+## Maintenance
+
+- 2025-09-25: Updated HTTP stack dependencies (Express 4.19.2, Axios 1.12.x, axios-retry 4.5.x) to incorporate vendor security patches.
+
 ## Configuration
 
 Copy the example environment file and configure it with your YouTrack instance details:

--- a/package.json
+++ b/package.json
@@ -34,10 +34,10 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^0.5.0",
     "@types/ws": "^8.18.1",
-    "axios": "^1.6.0",
-    "axios-retry": "^4.0.0",
+    "axios": "^1.12.2",
+    "axios-retry": "^4.5.0",
     "dotenv": "^16.6.1",
-    "express": "^4.18.0",
+    "express": "^4.19.2",
     "open": "^10.2.0",
     "winston": "^3.11.0",
     "ws": "^8.18.3"


### PR DESCRIPTION
## Summary
- bump Express, Axios, and axios-retry to patched releases addressing recent advisories
- regenerate npm lockfile metadata and verify build/test workflows
- document the dependency refresh in the maintenance notes

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d59ff0ae0c8320b91df20d2a2f4204